### PR TITLE
Do not use numpy.float.

### DIFF
--- a/src/ranker.py
+++ b/src/ranker.py
@@ -144,7 +144,7 @@ class DirectedCentralityRnak(object):
         cnt = 0
         for i in range(len(sentence_embeddings)-1):
             for j in range(i, len(sentence_embeddings)):
-                if type(sentence_embeddings[i]) == float or type(sentence_embeddings[i]) == np.float or type(sentence_embeddings[j]) == float or type(sentence_embeddings[j]) == np.float:
+                if type(sentence_embeddings[i]) == float or type(sentence_embeddings[j]) == float:
                     scores.append(0)
                 else:
                     scores.append(np.dot(sentence_embeddings[i], sentence_embeddings[j])) 
@@ -186,7 +186,7 @@ class DirectedCentralityRnak(object):
         new_matrix = similarity_matrix - threshold
         dist = []
         for emb in candidate_phrases_embeddings:
-            if type(doc_vector) == float or type(doc_vector) == np.float or type(emb) == float or type(emb) == np.float:
+            if type(doc_vector) == float or type(emb) == float:
                 dist.append(0)
             else:
                 dist.append(1/np.sum(np.abs(emb - doc_vector)))


### PR DESCRIPTION
Thank you for publish great library.
I want to use uke_ccrank with the latest numpy.

`numpy.float` was already deprecated and this is just alias to builtin `float`, we just check value is builtin `float` or not.

See
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations